### PR TITLE
Test failure should cause nonzero exit status

### DIFF
--- a/src/leiningen/test2junit.clj
+++ b/src/leiningen/test2junit.clj
@@ -52,10 +52,10 @@
                                             ['test2junit test2junit-version]]}]]
     (binding [leiningen.core.main/*exit-process?* false]
       (try
-        (apply leiningen.test/test (leiningen.core.project/merge-profiles project test2junit-profile) keys))
-      (catch clojure.lang.ExceptionInfo e
-        (if (:exit-code (ex-data e))
-          (do (generate-html project)
-              (throw e))
-          (println "Caught exception:" e)))))
+        (apply leiningen.test/test (leiningen.core.project/merge-profiles project test2junit-profile) keys)
+        (catch clojure.lang.ExceptionInfo e
+          (if (:exit-code (ex-data e))
+            (do (generate-html project)
+                (throw e))
+            (println "Caught exception:" e))))))
   (generate-html project))


### PR DESCRIPTION
As of 1.0.1, test2junit returns a 0 exit status even when there are test failures. This leads to confusing results in the console output of our CI build. 

I've changed exception handling logic such that test2junit.clj will _rethrow_ a caught exception if it contains an exit status, _after_ it has attempted to generate the HTML results.

This change also incorporates the change suggested in https://github.com/ruedigergad/test2junit/issues/1
